### PR TITLE
fix import error

### DIFF
--- a/src/signatory/__init__.py
+++ b/src/signatory/__init__.py
@@ -20,6 +20,7 @@ Documentation: https://signatory.readthedocs.io
 
 
 import torch  # must be imported before anything from signatory
+import sklearn
 
 try:
     from . import impl


### PR DESCRIPTION
Importing `sklearn` resolves the `_impl` import error on M2 MacBook.